### PR TITLE
Add path to systemdFolders for generated services

### DIFF
--- a/services-systemd@abteil.org/prefs.js
+++ b/services-systemd@abteil.org/prefs.js
@@ -8,7 +8,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 
-const systemdFolders = ['/lib/systemd/system/', '/etc/systemd/system/', '/usr/lib/systemd/user/'];
+const systemdFolders = ['/lib/systemd/system/', '/etc/systemd/system/', '/usr/lib/systemd/user/', '/run/systemd/generator.late/'];
 
 const ServicesSystemdSettings = new GObject.Class({
     Name: 'Services-Systemd-Settings',


### PR DESCRIPTION
On Ubuntu 15.10, installing software that does not support systemd is possible and there is an entry added in systemd automaticaly. For example, here is what I have for CrashPlan:

```
more /run/systemd/generator.late/crashplan.service
# Automatically generated by systemd-sysv-generator

[Unit]
Documentation=man:systemd-sysv-generator(8)
SourcePath=/etc/init.d/crashplan
Description=LSB: CrashPlan Engine
Before=graphical.target
After=local-fs.target network-online.target remote-fs.target
Wants=network-online.target

[Service]
Type=forking
Restart=no
TimeoutSec=5min
IgnoreSIGPIPE=no
KillMode=process
GuessMainPID=no
RemainAfterExit=yes
ExecStart=/etc/init.d/crashplan start
ExecStop=/etc/init.d/crashplan stop
```

So I can start / stop the CrashPlan engine with `sudo systemctl start crashplan.service`.

The issue is that the panel tells me this service does not exist when I try to add it :cry: This submission should fix this.

Thanks!