### PR TITLE
can manage SysV init services

### DIFF
--- a/services-systemd@abteil.org/prefs.js
+++ b/services-systemd@abteil.org/prefs.js
@@ -149,7 +149,7 @@ const ServicesSystemdSettings = new GObject.Class({
         this._onSelectionChanged();
     },
     _getSystemdServicesList: function(type) {
-        let [_, out, err, stat] = GLib.spawn_command_line_sync('sh -c "systemctl --' + type + ' list-unit-files --type=service | tail -n +2 | head -n -2 | awk \'{print $1}\'"');
+        let [_, out, err, stat] = GLib.spawn_command_line_sync('sh -c "systemctl --' + type + ' list-units --type=service --no-legend | awk \'{print $1}\'"');
         let allFiltered = out.toString().split("\n");
         return allFiltered.sort(
             function (a, b) {


### PR DESCRIPTION
in my use case, I wanted to add the `logstash.service` but this service is managed with the sysVinit `/etc/init.d/logstash` script.

Using `systemctl list-units --type=service` instead of `systemctl list-unit-files --type=services` allows to list those sysVinit script files as well.

Also the `--no-legend` option makes the `tail` / `head` trick unnecessary