### PR TITLE
additionally autocomplete sysVinit services

### DIFF
--- a/services-systemd@abteil.org/prefs.js
+++ b/services-systemd@abteil.org/prefs.js
@@ -149,8 +149,10 @@ const ServicesSystemdSettings = new GObject.Class({
         this._onSelectionChanged();
     },
     _getSystemdServicesList: function(type) {
-        let [_, out, err, stat] = GLib.spawn_command_line_sync('sh -c "systemctl --' + type + ' list-units --type=service --no-legend | awk \'{print $1}\'"');
+        let [_, out, err, stat] = GLib.spawn_command_line_sync('sh -c "systemctl --' + type + ' list-unit-files --type=service --no-legend | awk \'{print $1}\'"');
         let allFiltered = out.toString().split("\n");
+        let [_, out2, err, stat] = GLib.spawn_command_line_sync('sh -c "systemctl --' + type + ' list-units --type=service --no-legend | awk \'{print $1}\'"');
+        allFiltered = allFiltered.concat(out2.toString().split("\n"));
         return allFiltered.sort(
             function (a, b) {
                 return a.toLowerCase().localeCompare(b.toLowerCase());


### PR DESCRIPTION
when adding a service.

See #8 and specifically [this](https://github.com/petres/gnome-shell-extension-services-systemd/pull/8#issuecomment-234243722) comment