### PR TITLE
Update org.freedesktop.policykit.pkexec.systemctl.policy

### DIFF
--- a/org.freedesktop.policykit.pkexec.systemctl.policy
+++ b/org.freedesktop.policykit.pkexec.systemctl.policy
@@ -13,7 +13,7 @@
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/systemctl</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/bin/systemctl</annotate>
     <annotate key="org.freedesktop.policykit.exec.argv1">start</annotate>
   </action>
   <action id="org.freedesktop.policykit.pkexec.systemctl.stop">
@@ -25,7 +25,7 @@
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/systemctl</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/bin/systemctl</annotate>
     <annotate key="org.freedesktop.policykit.exec.argv1">stop</annotate>
   </action>
   <action id="org.freedesktop.policykit.pkexec.systemctl.restart">
@@ -37,7 +37,7 @@
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/systemctl</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/bin/systemctl</annotate>
     <annotate key="org.freedesktop.policykit.exec.argv1">restart</annotate>
   </action>
 </policyconfig>


### PR DESCRIPTION
systemctl is in /bin/systemctl not under /usr in my system. Ubuntu Gnome 17.04, i think Gnome 3.24.1