### PR TITLE
Update popupServiceItem for compatibility with Gnome 3.38

### DIFF
--- a/services-systemd@abteil.org/popupServiceItem.js
+++ b/services-systemd@abteil.org/popupServiceItem.js
@@ -1,28 +1,29 @@
+const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
+const Util = imports.misc.util;
 const { GObject, Gtk, St, Clutter} = imports.gi;
 
+const ExtensionSystem = imports.ui.extensionSystem;
+const ExtensionUtils = imports.misc.extensionUtils;
+
 var PopupServiceItem = GObject.registerClass(
-    class PopupServiceItem extends PopupMenu.PopupSwitchMenuItem {
-        _init(text, active, params) {
-            super._init(text, active);
+class PopupServiceItem extends PopupMenu.PopupSwitchMenuItem {
+    _init(text, active, params) {
+        super._init(text, active);
 
-            if (params.restartButton) {
-                this.restartButton = new St.Button({
-                    x_expand: false,
-                    x_align: Gtk.Align.END,
-                    reactive: true,
-                    can_focus: true,
-                    track_hover: true,
-                    accessible_name: 'restart',
-                    style_class: 'system-menu-action services-systemd-button-reload'
-                });
+        if (params.restartButton) {
+            this.restartButton = new St.Button({
+                x_align: St.Align.END,
+                x_expand: false,
+                reactive: true,
+                can_focus: true,
+                track_hover: true,
+                accessible_name: 'restart',
+                style_class: 'system-menu-action services-systemd-button-reload'
+            });
 
-                this.restartButton.add_actor(new St.Icon({
-                    icon_name: 'view-refresh-symbolic',
-                }));
-
-                this.add_child(this.restartButton);
-            }
+            this.restartButton.child = new St.Icon({ icon_name: 'view-refresh-symbolic' });
+            this.add_child(this.restartButton);
         }
     }
-);
+});


### PR DESCRIPTION
Tested and working for me on Archlinux with Gnome 3.38.  If using the aur -git package, you can update the PKGBUILD to pull from mtomlak as a source for a temporary workaround.